### PR TITLE
docs: add rule to avoid pushing to merged branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,4 @@ Use clear, descriptive commit messages following conventional commits:
 - **Small fixes should also use PR** - No matter how small, use issue + PR
 - **Describe changes clearly** - Both in commits and PR descriptions
 - **ALL changes require review** - Never merge PR yourself, always wait for owner review
+- **Never push to merged branches** - After PR is merged, delete the branch and create new one for new changes


### PR DESCRIPTION
## Summary
Add rule to CLAUDE.md about avoiding pushes to already merged branches.

## Changes
- Add rule: "Never push to merged branches - After PR is merged, delete the branch and create new one for new changes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)