### PR TITLE
docs: add rule to sync main before creating branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,4 @@ Use clear, descriptive commit messages following conventional commits:
 - **Describe changes clearly** - Both in commits and PR descriptions
 - **ALL changes require review** - Never merge PR yourself, always wait for owner review
 - **Never push to merged branches** - After PR is merged, delete the branch and create new one for new changes
+- **Always sync main before creating branch** - Run `git fetch origin && git reset --hard origin/main` before creating a new branch to avoid extra commits


### PR DESCRIPTION
## Summary
Add rule to CLAUDE.md about syncing main before creating a new branch.

## Changes
- Add rule: "Always sync main before creating branch - Run `git fetch origin && git reset --hard origin/main` before creating a new branch to avoid extra commits"

## Reason
To prevent PRs from having unexpected commits from an outdated main branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)